### PR TITLE
feat: add pino-caller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ prettyPrint | boolean |false| pretty print for developing purposes
 redact | array | undefined| array of paths in object to be redacted from the log
 destination | number / string | 1 | The stream to send the log to, or file
 base | object | {pid: process.pid, hostname: os.hostname} | Key-value object added as child logger to each log line
+pinoCaller | boolean | false | adds the call site of each log message to the log output 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "pino": "^8.11.0",
+        "pino-caller": "^3.4.0",
         "pino-pretty": "^10.0.0"
       },
       "devDependencies": {
@@ -4604,8 +4605,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/cachedir": {
       "version": "2.2.0",
@@ -11236,6 +11236,21 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/pino-caller": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pino-caller/-/pino-caller-3.4.0.tgz",
+      "integrity": "sha512-2aEjlmhLA7J3lGBXKDSxtlfDY+cBzGh5PnLFP6ZUhvyqCnqKfv28ulpSch6uymGIdo7fzxXHK2hvR5FrdzbhTg==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map-support": "^0.5.13"
+      },
+      "engines": {
+        "node": ">6.0.0"
+      },
+      "peerDependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/pino-pretty": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.0.tgz",
@@ -12155,7 +12170,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12164,7 +12178,6 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -16584,8 +16597,7 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "cachedir": {
       "version": "2.2.0",
@@ -21584,6 +21596,14 @@
         }
       }
     },
+    "pino-caller": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pino-caller/-/pino-caller-3.4.0.tgz",
+      "integrity": "sha512-2aEjlmhLA7J3lGBXKDSxtlfDY+cBzGh5PnLFP6ZUhvyqCnqKfv28ulpSch6uymGIdo7fzxXHK2hvR5FrdzbhTg==",
+      "requires": {
+        "source-map-support": "^0.5.13"
+      }
+    },
     "pino-pretty": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.0.tgz",
@@ -22255,14 +22275,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "pino": "^8.11.0",
+    "pino-caller": "^3.4.0",
     "pino-pretty": "^10.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import pino, { LoggerOptions as PinoOptions, Logger, TransportSingleOptions } from 'pino';
+import pinoCaller from 'pino-caller';
 
-type LoggerOptions = Pick<PinoOptions, 'enabled' | 'level' | 'redact' | 'hooks' | 'base' | 'mixin'> & { prettyPrint?: boolean };
+type LoggerOptions = Pick<PinoOptions, 'enabled' | 'level' | 'redact' | 'hooks' | 'base' | 'mixin'> & { prettyPrint?: boolean; pinoCaller?: boolean };
 
 const baseOptions: PinoOptions = {
   formatters: {
@@ -20,7 +21,9 @@ const jsLogger = (options?: LoggerOptions, destination: string | number = 1): Lo
   }
 
   const pinoOptions: PinoOptions = { ...baseOptions, ...options, transport };
-  return pino(pinoOptions, pino.destination(destination));
+  const logger = pino(pinoOptions, pino.destination(destination));
+  const loggerWithCaller = pinoCaller(logger);
+  return options?.pinoCaller === true ? loggerWithCaller : logger;
 };
 
 export { Logger } from 'pino';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,12 @@ const jsLogger = (options?: LoggerOptions, destination: string | number = 1): Lo
 
   const pinoOptions: PinoOptions = { ...baseOptions, ...options, transport };
   const logger = pino(pinoOptions, pino.destination(destination));
-  const loggerWithCaller = pinoCaller(logger);
-  return options?.pinoCaller === true ? loggerWithCaller : logger;
+
+  if (options?.pinoCaller === true) {
+    return pinoCaller(logger);
+  }
+
+  return logger;
 };
 
 export { Logger } from 'pino';


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
Add support of pino-caller.
pino-caller adds the call site of each log message to the log output 
